### PR TITLE
Add hyperinflationary regime

### DIFF
--- a/types/inflation_curve.go
+++ b/types/inflation_curve.go
@@ -1,0 +1,226 @@
+package types
+
+import (
+	"math/big"
+)
+
+// Stores constants needed for inflation curve calculation.
+// The original Rust implementation this is generated from can be found in
+// https://github.com/AaronKutch/mint_test
+//
+// Note about performance: the original implementation was designed so that no allocations happen
+// after the constants are initialized. Go's bigint library might be allocating for every
+// multiplication, we need to port over some things from `awint` if we want to speed this up.
+type InflationCurve struct {
+	// for exp2m1
+	constants [30]*big.Int
+	// for base change
+	lbE *big.Int
+	// for large 1.0 value
+	exp2FwOne *big.Int
+	// for curve peak position
+	peakOffset *big.Int
+	// adjusts peak height
+	peakScale *big.Int
+}
+
+// Use `GlobalInflationCurve` instead of needing to call this function more than once
+func newInflationCurve() *InflationCurve {
+	ic := InflationCurve{}
+	var i = new(big.Int)
+	i, _ = new(big.Int).SetString("21", 10)
+	ic.constants[0] = i
+	i, _ = new(big.Int).SetString("931", 10)
+	ic.constants[1] = i
+	i, _ = new(big.Int).SetString("38977", 10)
+	ic.constants[2] = i
+	i, _ = new(big.Int).SetString("1574505", 10)
+	ic.constants[3] = i
+	i, _ = new(big.Int).SetString("61331333", 10)
+	ic.constants[4] = i
+	i, _ = new(big.Int).SetString("2300542666", 10)
+	ic.constants[5] = i
+	i, _ = new(big.Int).SetString("82974537419", 10)
+	ic.constants[6] = i
+	i, _ = new(big.Int).SetString("2872966887729", 10)
+	ic.constants[7] = i
+	i, _ = new(big.Int).SetString("95330746876023", 10)
+	ic.constants[8] = i
+	i, _ = new(big.Int).SetString("3025730306770147", 10)
+	ic.constants[9] = i
+	i, _ = new(big.Int).SetString("91669328281539416", 10)
+	ic.constants[10] = i
+	i, _ = new(big.Int).SetString("2645017706267986357", 10)
+	ic.constants[11] = i
+	i, _ = new(big.Int).SetString("72503124630030170854", 10)
+	ic.constants[12] = i
+	i, _ = new(big.Int).SetString("1882798170348581770631", 10)
+	ic.constants[13] = i
+	i, _ = new(big.Int).SetString("46177160917064115362943", 10)
+	ic.constants[14] = i
+	i, _ = new(big.Int).SetString("1065912976918080910514347", 10)
+	ic.constants[15] = i
+	i, _ = new(big.Int).SetString("23066810487283611717419874", 10)
+	ic.constants[16] = i
+	i, _ = new(big.Int).SetString("465897223387814402039923456", 10)
+	ic.constants[17] = i
+	i, _ = new(big.Int).SetString("8737918978691986426796998167", 10)
+	ic.constants[18] = i
+	i, _ = new(big.Int).SetString("151273828538981816810644004423", 10)
+	ic.constants[19] = i
+	i, _ = new(big.Int).SetString("2400662024744240530078289187559", 10)
+	ic.constants[20] = i
+	i, _ = new(big.Int).SetString("34634231979489737747471345012729", 10)
+	ic.constants[21] = i
+	i, _ = new(big.Int).SetString("449699712496270121258630534506364", 10)
+	ic.constants[22] = i
+	i, _ = new(big.Int).SetString("5190236360860492089195900933424948", 10)
+	ic.constants[23] = i
+	i, _ = new(big.Int).SetString("52415497811985085885772577715591695", 10)
+	ic.constants[24] = i
+	i, _ = new(big.Int).SetString("453717472554463172968722258900220684", 10)
+	ic.constants[25] = i
+	i, _ = new(big.Int).SetString("3272879738094991899426931849626998944", 10)
+	ic.constants[26] = i
+	i, _ = new(big.Int).SetString("18887069470302456743998381224473040631", 10)
+	ic.constants[27] = i
+	i, _ = new(big.Int).SetString("81744844385192085827234082247051493269", 10)
+	ic.constants[28] = i
+	i, _ = new(big.Int).SetString("235865763225513294137944142764154484399", 10)
+	ic.constants[29] = i
+	i, _ = new(big.Int).SetString("490923683258796565746369346286093237521", 10)
+	ic.lbE = i
+	i, _ = new(big.Int).SetString("340282366920938463463374607431768211456", 10)
+	ic.exp2FwOne = i
+	i, _ = new(big.Int).SetString("-150000000000000000000000000", 10)
+	ic.peakOffset = i
+	i, _ = new(big.Int).SetString("-7880401239278895842455808020028722761015947854093089333589658680", 10)
+	ic.peakScale = i
+	return &ic
+}
+
+// Contains the constants needed for inflation curve calculation
+var GlobalInflationCurve = newInflationCurve()
+
+// Calculates `2^x - 1` using a 128 bit fracint
+func (ic *InflationCurve) exp2m1Fracint(x *big.Int) *big.Int {
+	// upstream invariants should prevent this, but check
+	// just in case because a width explosion happens otherwise
+	if x.BitLen() > 128 {
+		return nil
+	}
+	var h = new(big.Int)
+	for _, c := range ic.constants {
+		h.Add(h, c)
+		h.Mul(h, x)
+		// shift from fp = 256 to fp = 128
+		h.Rsh(h, 128)
+	}
+	return h
+}
+
+func unsignedAbs(x int) uint {
+	if x < 0 {
+		// arithmetic is wrapping in Go so this handles imin correctly
+		return uint(-x)
+	} else {
+		return uint(x)
+	}
+}
+
+// Calculates `e^x`. Input and output are {i,u}128f64 bit fixed point integers.
+// Returns `nil` if the result overflows 128 bits.
+func (ic *InflationCurve) exp(x *big.Int) *big.Int {
+	if x.BitLen() > 128 {
+		return nil
+	}
+	var msb = x.Sign() == -1
+	// make unsigned
+	x.Abs(x)
+	// convert bases
+	x.Mul(x, ic.lbE)
+	// lbE.fp + x.fp = 128 + 64 = 192
+	var intPart = new(big.Int).Rsh(x, 192)
+	// extract the fractional part
+	var fracPart = new(big.Int).Lsh(intPart, 192)
+	fracPart.Sub(x, fracPart)
+	// get to fp = 128
+	fracPart.Rsh(fracPart, 64)
+
+	if !intPart.IsInt64() {
+		// certain overflow
+		return nil
+	} else {
+		// note: we assume `int` is 64 bits
+		var shift = int(intPart.Int64())
+		if msb {
+			shift = -shift - 1
+			// two's complement without changing the sign
+			fracPart.Sub(ic.exp2FwOne, fracPart)
+		}
+		// include shift from fp=128 to fp=64
+		shift -= 64
+
+		// calculate exp2
+		var res = ic.exp2m1Fracint(fracPart)
+		res.Or(res, ic.exp2FwOne)
+
+		switch {
+		case shift < 0:
+			var shift = unsignedAbs(shift)
+			if shift >= 128 {
+				// shift is large enough to guarantee zero
+				return new(big.Int)
+			} else {
+				res.Rsh(res, shift)
+			}
+		case shift <= (128 - res.BitLen()):
+			res.Lsh(res, unsignedAbs(shift))
+			if res.BitLen() > 128 {
+				return nil
+			}
+		default:
+			// guaranteed overflow from large positive shift
+			return nil
+		}
+		return res
+	}
+}
+
+// Calculates `e^(-((x-peak_position)^2 / (2*(std_dev^2)))))`.
+// `anomSupply` is in units of aNom. Returns a fixed point integer capped at 1.0u65f64.
+func (ic *InflationCurve) calculateInflationBinary(anomSupply *big.Int) *big.Int {
+	if anomSupply.BitLen() >= 90 {
+		// guaranteed < 2^-64
+		return new(big.Int)
+	}
+	// apply offset
+	var tmp = new(big.Int).Add(anomSupply, ic.peakOffset)
+	// square
+	tmp.Mul(tmp, tmp)
+	// scale
+	tmp.Mul(tmp, ic.peakScale)
+	// keep at fp = 64
+	tmp.Rsh(tmp, 320)
+	var res = ic.exp(tmp)
+	if res == nil {
+		// return zero
+		return new(big.Int)
+	}
+	return res
+}
+
+// The same as `calculateInflationBinary` but with an `Int` input and `Dec` output
+func (ic *InflationCurve) CalculateInflationDec(anomSupply Int) Dec {
+	// People keep committing the same horrible mistake of using base 10 fixed point numbers at the
+	// computational layer instead of converting between binary fixed point at the human-machine
+	// interface by using banker's rounding which is already inevitable. Above, we absolutely
+	// needed binary fixed point to do fast divisions by powers of two, but the output here needs
+	// to be a `Dec`.
+	var tmp = ic.calculateInflationBinary(anomSupply.BigInt())
+	// multiply by 10^18 to get to maximum precision allowed by `Dec`
+	tmp.Mul(tmp, precisionReuse)
+	// remove binary fixed point component
+	tmp.Rsh(tmp, 64)
+	return NewDecFromBigIntWithPrec(tmp, 18)
+}

--- a/x/bank/client/cli/cli_test.go
+++ b/x/bank/client/cli/cli_test.go
@@ -182,7 +182,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryTotalSupply() {
 			expected: &types.QueryTotalSupplyResponse{
 				Supply: sdk.NewCoins(
 					sdk.NewCoin(fmt.Sprintf("%stoken", val.Moniker), s.cfg.AccountTokens),
-					sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens.Add(sdk.NewInt(10))),
+					sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens),
 				)},
 		},
 		{
@@ -193,7 +193,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryTotalSupply() {
 				fmt.Sprintf("--%s=json", tmcli.OutputFlag),
 			},
 			respType: &sdk.Coin{},
-			expected: &sdk.Coin{s.cfg.BondDenom, s.cfg.StakingTokens.Add(sdk.NewInt(10))},
+			expected: &sdk.Coin{s.cfg.BondDenom, s.cfg.StakingTokens},
 		},
 		{
 			name: "total supply of a bogus denom",

--- a/x/bank/client/rest/grpc_query_test.go
+++ b/x/bank/client/rest/grpc_query_test.go
@@ -36,7 +36,7 @@ func (s *IntegrationTestSuite) TestTotalSupplyGRPCHandler() {
 			&types.QueryTotalSupplyResponse{
 				Supply: sdk.NewCoins(
 					sdk.NewCoin(fmt.Sprintf("%stoken", val.Moniker), s.cfg.AccountTokens),
-					sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens.Add(sdk.NewInt(10))),
+					sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens),
 				),
 			},
 		},
@@ -48,7 +48,7 @@ func (s *IntegrationTestSuite) TestTotalSupplyGRPCHandler() {
 			},
 			&types.QuerySupplyOfResponse{},
 			&types.QuerySupplyOfResponse{
-				Amount: sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens.Add(sdk.NewInt(10))),
+				Amount: sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens),
 			},
 		},
 		{
@@ -59,7 +59,7 @@ func (s *IntegrationTestSuite) TestTotalSupplyGRPCHandler() {
 			},
 			&types.QuerySupplyOfResponse{},
 			&types.QuerySupplyOfResponse{
-				Amount: sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens.Add(sdk.NewInt(20))),
+				Amount: sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens),
 			},
 		},
 		{
@@ -70,7 +70,7 @@ func (s *IntegrationTestSuite) TestTotalSupplyGRPCHandler() {
 			},
 			&types.QuerySupplyOfResponse{},
 			&types.QuerySupplyOfResponse{
-				Amount: sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens.Add(sdk.NewInt(10))),
+				Amount: sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens),
 			},
 		},
 		{

--- a/x/bank/client/rest/query_test.go
+++ b/x/bank/client/rest/query_test.go
@@ -156,14 +156,14 @@ func (s *IntegrationTestSuite) TestTotalSupplyHandlerFn() {
 			&sdk.Coins{},
 			sdk.NewCoins(
 				sdk.NewCoin(fmt.Sprintf("%stoken", val.Moniker), s.cfg.AccountTokens),
-				sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens.Add(sdk.NewInt(10))),
+				sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens),
 			),
 		},
 		{
 			"total supply of a specific denom",
 			fmt.Sprintf("%s/bank/total/%s?height=1", baseURL, s.cfg.BondDenom),
 			&sdk.Coin{},
-			sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens.Add(sdk.NewInt(10))),
+			sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens),
 		},
 		{
 			"total supply of a bogus denom",

--- a/x/mint/abci.go
+++ b/x/mint/abci.go
@@ -20,7 +20,7 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
 	// recalculate inflation rate
 	totalStakingSupply := k.StakingTokenSupply(ctx)
 	bondedRatio := k.BondedRatio(ctx)
-	minter.Inflation = minter.NextInflationRate(params, bondedRatio)
+	minter.Inflation = minter.NextInflationRate(params, bondedRatio, totalStakingSupply)
 	minter.AnnualProvisions = minter.NextAnnualProvisions(params, totalStakingSupply)
 	k.SetMinter(ctx, minter)
 

--- a/x/mint/simulation/genesis_test.go
+++ b/x/mint/simulation/genesis_test.go
@@ -51,7 +51,8 @@ func TestRandomizedGenState(t *testing.T) {
 	require.Equal(t, "stake", mintGenesis.Params.MintDenom)
 	require.Equal(t, "0stake", mintGenesis.Minter.BlockProvision(mintGenesis.Params).String())
 	require.Equal(t, "0.170000000000000000", mintGenesis.Minter.NextAnnualProvisions(mintGenesis.Params, sdk.OneInt()).String())
-	require.Equal(t, "0.169999926644441493", mintGenesis.Minter.NextInflationRate(mintGenesis.Params, sdk.OneDec()).String())
+	require.Equal(t, "0.169999926644441493", mintGenesis.Minter.NextInflationRate(mintGenesis.Params, sdk.OneDec(), sdk.NewIntWithDecimal(250_000_000, 18)).String())
+	require.Equal(t, "0.135335283236612691", mintGenesis.Minter.NextInflationRate(mintGenesis.Params, sdk.OneDec(), sdk.NewIntWithDecimal(50_000_000, 18)).String())
 	require.Equal(t, "0.170000000000000000", mintGenesis.Minter.Inflation.String())
 	require.Equal(t, "0.000000000000000000", mintGenesis.Minter.AnnualProvisions.String())
 }

--- a/x/mint/types/minter_test.go
+++ b/x/mint/types/minter_test.go
@@ -17,36 +17,46 @@ func TestNextInflation(t *testing.T) {
 	// Governing Mechanism:
 	//    inflationRateChangePerYear = (1- BondedRatio/ GoalBonded) * MaxInflationRateChange
 
+	var stableSupply = sdk.NewIntWithDecimal(250_000_000, 18)
+	var dec50m, _ = sdk.NewDecFromStr("0.135335283236612691")
+	var dec150m, _ = sdk.NewDecFromStr("1.000000000000000000")
+	var dec200m, _ = sdk.NewDecFromStr("0.606530659712633423")
 	tests := []struct {
 		bondedRatio, setInflation, expChange sdk.Dec
+		totalSupply                          sdk.Int
 	}{
 		// with 0% bonded atom supply the inflation should increase by InflationRateChange
-		{sdk.ZeroDec(), sdk.NewDecWithPrec(7, 2), params.InflationRateChange.Quo(blocksPerYr)},
+		{sdk.ZeroDec(), sdk.NewDecWithPrec(7, 2), params.InflationRateChange.Quo(blocksPerYr), stableSupply},
 
 		// 100% bonded, starting at 20% inflation and being reduced
 		// (1 - (1/0.67))*(0.13/8667)
 		{sdk.OneDec(), sdk.NewDecWithPrec(20, 2),
-			sdk.OneDec().Sub(sdk.OneDec().Quo(params.GoalBonded)).Mul(params.InflationRateChange).Quo(blocksPerYr)},
+			sdk.OneDec().Sub(sdk.OneDec().Quo(params.GoalBonded)).Mul(params.InflationRateChange).Quo(blocksPerYr), stableSupply},
 
 		// 50% bonded, starting at 10% inflation and being increased
 		{sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(10, 2),
-			sdk.OneDec().Sub(sdk.NewDecWithPrec(5, 1).Quo(params.GoalBonded)).Mul(params.InflationRateChange).Quo(blocksPerYr)},
+			sdk.OneDec().Sub(sdk.NewDecWithPrec(5, 1).Quo(params.GoalBonded)).Mul(params.InflationRateChange).Quo(blocksPerYr), stableSupply},
 
 		// test 7% minimum stop (testing with 100% bonded)
-		{sdk.OneDec(), sdk.NewDecWithPrec(7, 2), sdk.ZeroDec()},
-		{sdk.OneDec(), sdk.NewDecWithPrec(700000001, 10), sdk.NewDecWithPrec(-1, 10)},
+		{sdk.OneDec(), sdk.NewDecWithPrec(7, 2), sdk.ZeroDec(), stableSupply},
+		{sdk.OneDec(), sdk.NewDecWithPrec(700000001, 10), sdk.NewDecWithPrec(-1, 10), stableSupply},
 
 		// test 20% maximum stop (testing with 0% bonded)
-		{sdk.ZeroDec(), sdk.NewDecWithPrec(20, 2), sdk.ZeroDec()},
-		{sdk.ZeroDec(), sdk.NewDecWithPrec(1999999999, 10), sdk.NewDecWithPrec(1, 10)},
+		{sdk.ZeroDec(), sdk.NewDecWithPrec(20, 2), sdk.ZeroDec(), stableSupply},
+		{sdk.ZeroDec(), sdk.NewDecWithPrec(1999999999, 10), sdk.NewDecWithPrec(1, 10), stableSupply},
 
 		// perfect balance shouldn't change inflation
-		{sdk.NewDecWithPrec(67, 2), sdk.NewDecWithPrec(15, 2), sdk.ZeroDec()},
+		{sdk.NewDecWithPrec(67, 2), sdk.NewDecWithPrec(15, 2), sdk.ZeroDec(), stableSupply},
+
+		// test hyperinflationary regime
+		{sdk.ZeroDec(), dec50m, sdk.ZeroDec(), sdk.NewIntWithDecimal(50_000_000, 18)},
+		{sdk.ZeroDec(), dec150m, sdk.ZeroDec(), sdk.NewIntWithDecimal(150_000_000, 18)},
+		{sdk.ZeroDec(), dec200m, sdk.ZeroDec(), sdk.NewIntWithDecimal(200_000_000, 18)},
 	}
 	for i, tc := range tests {
 		minter.Inflation = tc.setInflation
 
-		inflation := minter.NextInflationRate(params, tc.bondedRatio)
+		inflation := minter.NextInflationRate(params, tc.bondedRatio, tc.totalSupply)
 		diffInflation := inflation.Sub(tc.setInflation)
 
 		require.True(t, diffInflation.Equal(tc.expChange),
@@ -111,9 +121,9 @@ func BenchmarkNextInflation(b *testing.B) {
 
 	// run the NextInflationRate function b.N times
 	for n := 0; n < b.N; n++ {
-		minter.NextInflationRate(params, bondedRatio)
+		// the hyperinflationary regime is by far the most expensive to calculate
+		minter.NextInflationRate(params, bondedRatio, sdk.NewInt(100_000_000))
 	}
-
 }
 
 // Next annual provisions benchmarking
@@ -127,5 +137,4 @@ func BenchmarkNextAnnualProvisions(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		minter.NextAnnualProvisions(params, totalSupply)
 	}
-
 }


### PR DESCRIPTION
## Description

Adds the file `inflation_curve.go` which contains structs and functions for quickly calculating an accurate hyperinflation curve for the new spec. Edited `minter.go` to dynamically switch between regimes. Edited old tests so they still test the infinite stabilized regime. In some places I removed an `.Add(sdk.NewInt(10))`, which I _think_ existed because of a small rate change that would happen in tests that previously took place during the stabilized regime. Added a few new test cases for the new regime.

There are currently a few GRPC related tests that fail because a totalSupply somewhere is starting at zero (which leads to the inflation being the 0.0111089... value). I don't know where to fix the total supply or if I should just change the tests to expect the 0.0111 value even though we will be starting the supply at 50M in genesis.

There are also a few failing tests involving annual_provisions and validator rewards with empty outputs, but I don't know why my changes affected those.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
