### PR TITLE
"add-genesis-account" cli with periodic vesting

### DIFF
--- a/simapp/simd/cmd/genaccounts.go
+++ b/simapp/simd/cmd/genaccounts.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -22,9 +24,11 @@ import (
 )
 
 const (
-	flagVestingStart = "vesting-start-time"
-	flagVestingEnd   = "vesting-end-time"
-	flagVestingAmt   = "vesting-amount"
+	FlagVestingStart         = "vesting-start-time"
+	FlagVestingEnd           = "vesting-end-time"
+	FlagVestingAmt           = "vesting-amount"
+	FlagVestingPeriodsNumber = "vesting-periods-number"
+	FlagVestingPeriodsAmts   = "vesting-periods-amounts"
 )
 
 // AddGenesisAccountCmd returns add-genesis-account cobra Command.
@@ -72,9 +76,11 @@ contain valid denominations. Accounts may optionally be supplied with vesting pa
 				return fmt.Errorf("failed to parse coins: %w", err)
 			}
 
-			vestingStart, _ := cmd.Flags().GetInt64(flagVestingStart)
-			vestingEnd, _ := cmd.Flags().GetInt64(flagVestingEnd)
-			vestingAmtStr, _ := cmd.Flags().GetString(flagVestingAmt)
+			vestingStart, _ := cmd.Flags().GetInt64(FlagVestingStart)
+			vestingEnd, _ := cmd.Flags().GetInt64(FlagVestingEnd)
+			vestingAmtStr, _ := cmd.Flags().GetString(FlagVestingAmt)
+			vestingPeriodsNumber, _ := cmd.Flags().GetInt64(FlagVestingPeriodsNumber)
+			vestingPeriodsAmts, _ := cmd.Flags().GetString(FlagVestingPeriodsAmts)
 
 			vestingAmt, err := sdk.ParseCoinsNormalized(vestingAmtStr)
 			if err != nil {
@@ -96,6 +102,73 @@ contain valid denominations. Accounts may optionally be supplied with vesting pa
 				}
 
 				switch {
+
+				case vestingStart > 0 && vestingEnd > 0 && (vestingPeriodsNumber > 0 || vestingPeriodsAmts != ""):
+					{
+						if vestingPeriodsNumber > 0 && vestingPeriodsAmts != "" {
+							return fmt.Errorf("the flags %s and %s can't be used at the same time", FlagVestingPeriodsNumber, FlagVestingPeriodsAmts)
+						}
+
+						periods := make(authvesting.Periods, 0)
+
+						if vestingPeriodsNumber > 0 {
+
+							if vestingPeriodsNumber < 1 {
+								return fmt.Errorf("parameter %s must be >=2 since at least 2 periods start and and are required", FlagVestingPeriodsNumber)
+							}
+
+							vestingDenom := vestingAmt.GetDenomByIndex(0)
+							periodLength := (vestingEnd - vestingStart) / (vestingPeriodsNumber - 1)
+							periodAmount := vestingAmt.AmountOf(vestingDenom).Quo(sdk.NewInt(vestingPeriodsNumber))
+							periodCoins := sdk.NewCoins(sdk.NewCoin(vestingDenom, periodAmount))
+
+							for i := 0; i < int(vestingPeriodsNumber); i++ {
+								periods = append(periods, authvesting.Period{
+									Length: periodLength,
+									Amount: periodCoins,
+								})
+							}
+							if len(periods) > 0 {
+								// execute the first period at the start date
+								periods[0].Length = 0
+							}
+						}
+
+						if vestingPeriodsAmts != "" {
+							amtSum := make(sdk.Coins, 0)
+							periodLengthSum := 0
+
+							vestingPeriodsAmtsStrings := strings.Split(vestingPeriodsAmts, ",")
+							for _, vestingPeriodString := range vestingPeriodsAmtsStrings {
+								vestingPeriodPair := strings.Split(vestingPeriodString, "|")
+								if len(vestingPeriodPair) != 2 {
+									return fmt.Errorf("vestingPeriodPair %s is invalid", vestingPeriodString)
+								}
+								epochString := vestingPeriodPair[0]
+								periodLength, err := strconv.Atoi(epochString)
+								if err != nil || periodLength <= 0 {
+									return fmt.Errorf("invalid epoch in periods: %w", err)
+								}
+
+								coinAmountString := vestingPeriodPair[1]
+								periodCoins, err := sdk.ParseCoinsNormalized(coinAmountString)
+								if err != nil {
+									return fmt.Errorf("failed to parse vesting amount: %w", err)
+								}
+
+								periods = append(periods, authvesting.Period{
+									Length: int64(periodLength),
+									Amount: periodCoins,
+								})
+
+								amtSum = amtSum.Add(periodCoins...)
+								periodLengthSum += periodLength
+							}
+						}
+
+						genAccount = authvesting.NewPeriodicVestingAccountRaw(baseVestingAccount, vestingStart, periods)
+					}
+
 				case vestingStart != 0 && vestingEnd != 0:
 					genAccount = authvesting.NewContinuousVestingAccountRaw(baseVestingAccount, vestingStart)
 
@@ -172,9 +245,11 @@ contain valid denominations. Accounts may optionally be supplied with vesting pa
 
 	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
 	cmd.Flags().String(flags.FlagKeyringBackend, flags.DefaultKeyringBackend, "Select keyring's backend (os|file|kwallet|pass|test)")
-	cmd.Flags().String(flagVestingAmt, "", "amount of coins for vesting accounts")
-	cmd.Flags().Int64(flagVestingStart, 0, "schedule start time (unix epoch) for vesting accounts")
-	cmd.Flags().Int64(flagVestingEnd, 0, "schedule end time (unix epoch) for vesting accounts")
+	cmd.Flags().String(FlagVestingAmt, "", "amount of coins for vesting accounts")
+	cmd.Flags().Int64(FlagVestingStart, 0, "schedule start time (unix epoch) for vesting accounts")
+	cmd.Flags().Int64(FlagVestingEnd, 0, "schedule end time (unix epoch) for vesting accounts")
+	cmd.Flags().Int64(FlagVestingPeriodsNumber, 0, "number of periods for vesting before the start and end time")
+	cmd.Flags().String(FlagVestingPeriodsAmts, "", "the array of the \"epoch|amountDenom,epoch|amountDenom\", values for the periodic for vesting")
 	flags.AddQueryFlagsToCmd(cmd)
 
 	return cmd

--- a/simapp/simd/cmd/genaccounts_test.go
+++ b/simapp/simd/cmd/genaccounts_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/log"
 
@@ -15,9 +16,13 @@ import (
 	"github.com/cosmos/cosmos-sdk/simapp"
 	simcmd "github.com/cosmos/cosmos-sdk/simapp/simd/cmd"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
+	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltest "github.com/cosmos/cosmos-sdk/x/genutil/client/testutil"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 )
 
 var testMbm = module.NewBasicManager(genutil.AppModuleBasic{})
@@ -25,10 +30,17 @@ var testMbm = module.NewBasicManager(genutil.AppModuleBasic{})
 func TestAddGenesisAccountCmd(t *testing.T) {
 	_, _, addr1 := testdata.KeyTestPubAddr()
 	tests := []struct {
-		name      string
-		addr      string
-		denom     string
+		name                  string
+		addr                  string
+		denom                 string
+		vestingStartTime      uint64
+		vestingEndTime        uint64
+		vestingAmount         string
+		vestingPeriodsNumber  uint64
+		vestingPeriodsAmounts string
+
 		expectErr bool
+		want      authtypes.GenesisAccounts
 	}{
 		{
 			name:      "invalid address",
@@ -47,6 +59,107 @@ func TestAddGenesisAccountCmd(t *testing.T) {
 			addr:      addr1.String(),
 			denom:     "1000atom, 2000stake",
 			expectErr: false,
+		},
+		{
+			name:             "continuous vesting",
+			addr:             addr1.String(),
+			denom:            "1000atom",
+			vestingAmount:    "1000atom",
+			vestingStartTime: 1640620000,
+			vestingEndTime:   1640630000,
+			expectErr:        false,
+			want: []authtypes.GenesisAccount{
+				&vestingtypes.ContinuousVestingAccount{
+					BaseVestingAccount: &vestingtypes.BaseVestingAccount{
+						BaseAccount: &authtypes.BaseAccount{
+							Address: addr1.String(),
+						},
+						OriginalVesting:  types.NewCoins(types.NewCoin("atom", types.NewInt(1000))),
+						DelegatedFree:    nil,
+						DelegatedVesting: nil,
+						EndTime:          1640630000,
+					},
+					StartTime: 1640620000,
+				},
+			},
+		},
+		{
+			name:                 "periodic vesting with vesting-periods-number",
+			addr:                 addr1.String(),
+			denom:                "1000atom",
+			vestingAmount:        "1000atom",
+			vestingStartTime:     1640620000,
+			vestingEndTime:       1640629000,
+			vestingPeriodsNumber: 10,
+			expectErr:            false,
+			want: []authtypes.GenesisAccount{
+				&vestingtypes.PeriodicVestingAccount{
+					BaseVestingAccount: &vestingtypes.BaseVestingAccount{
+						BaseAccount: &authtypes.BaseAccount{
+							Address: addr1.String(),
+						},
+						OriginalVesting:  types.NewCoins(types.NewCoin("atom", types.NewInt(1000))),
+						DelegatedFree:    nil,
+						DelegatedVesting: nil,
+						EndTime:          1640629000,
+					},
+					StartTime: 1640620000,
+					VestingPeriods: func() vestingtypes.Periods {
+						vestingPeriods := make(vestingtypes.Periods, 0)
+						// vest each 1000 millis 10 times
+						for i := 0; i < 10; i++ {
+							vestingPeriods = append(vestingPeriods, vestingtypes.Period{
+								Length: 1000,
+								Amount: types.NewCoins(types.NewCoin("atom", types.NewInt(100))),
+							})
+						}
+						vestingPeriods[0].Length = 0
+						return vestingPeriods
+					}(),
+				},
+			},
+		},
+		{
+			name:                  "periodic vesting with vesting-periods-amounts",
+			addr:                  addr1.String(),
+			denom:                 "1000atom",
+			vestingAmount:         "1000atom",
+			vestingStartTime:      1640620000,
+			vestingEndTime:        1640630000,
+			vestingPeriodsAmounts: "9000|100atom,900|800atom,100|100atom",
+			expectErr:             false,
+			want: []authtypes.GenesisAccount{
+				&vestingtypes.PeriodicVestingAccount{
+					BaseVestingAccount: &vestingtypes.BaseVestingAccount{
+						BaseAccount: &authtypes.BaseAccount{
+							Address: addr1.String(),
+						},
+						OriginalVesting:  types.NewCoins(types.NewCoin("atom", types.NewInt(1000))),
+						DelegatedFree:    nil,
+						DelegatedVesting: nil,
+						EndTime:          1640630000,
+					},
+					StartTime: 1640620000,
+					VestingPeriods: func() vestingtypes.Periods {
+						vestingPeriods := vestingtypes.Periods{
+							{
+								Length: 9000,
+								Amount: types.NewCoins(types.NewCoin("atom", types.NewInt(100))),
+							},
+							{
+								Length: 900,
+								Amount: types.NewCoins(types.NewCoin("atom", types.NewInt(800))),
+							},
+							{
+								Length: 100,
+								Amount: types.NewCoins(types.NewCoin("atom", types.NewInt(100))),
+							},
+						}
+
+						return vestingPeriods
+					}(),
+				},
+			},
 		},
 	}
 
@@ -70,15 +183,51 @@ func TestAddGenesisAccountCmd(t *testing.T) {
 			ctx = context.WithValue(ctx, server.ServerContextKey, serverCtx)
 
 			cmd := simcmd.AddGenesisAccountCmd(home)
-			cmd.SetArgs([]string{
+			args := []string{
 				tc.addr,
 				tc.denom,
-				fmt.Sprintf("--%s=home", flags.FlagHome)})
+			}
 
+			if tc.vestingStartTime > 0 {
+				args = append(args, fmt.Sprintf("--%s=%d", simcmd.FlagVestingStart, tc.vestingStartTime))
+			}
+			if tc.vestingEndTime > 0 {
+				args = append(args, fmt.Sprintf("--%s=%d", simcmd.FlagVestingEnd, tc.vestingEndTime))
+			}
+			if tc.vestingAmount != "" {
+				args = append(args, fmt.Sprintf("--%s=%s", simcmd.FlagVestingAmt, tc.vestingAmount))
+			}
+			if tc.vestingPeriodsNumber > 0 {
+				args = append(args, fmt.Sprintf("--%s=%d", simcmd.FlagVestingPeriodsNumber, tc.vestingPeriodsNumber))
+			}
+			if tc.vestingPeriodsAmounts != "" {
+				args = append(args, fmt.Sprintf("--%s=%s", simcmd.FlagVestingPeriodsAmts, tc.vestingPeriodsAmounts))
+			}
+
+			args = append(args, fmt.Sprintf("--%s=home", flags.FlagHome))
+
+			cmd.SetArgs(args)
 			if tc.expectErr {
 				require.Error(t, cmd.ExecuteContext(ctx))
 			} else {
 				require.NoError(t, cmd.ExecuteContext(ctx))
+			}
+
+			genFile := cfg.GenesisFile()
+			appState, _, err := genutiltypes.GenesisStateFromGenFile(genFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			authGenState := authtypes.GetGenesisStateFromAppState(appCodec, appState)
+
+			accs, err := authtypes.UnpackAccounts(authGenState.Accounts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.want != nil {
+				assert.Equal(t, tc.want, accs)
 			}
 		})
 	}


### PR DESCRIPTION
The "add-genesis-account" CLI command didn't support the periodic vesting accounts. 
That PR contains the extensibility for the generic "add-genesis-account" CLI that helps to create periodic vesting genesys accounts.