### PR TITLE
feat: Proposer in gov proposal content

### DIFF
--- a/contrib/devtools/dockerfile
+++ b/contrib/devtools/dockerfile
@@ -2,7 +2,7 @@ FROM bufbuild/buf:0.53.0 as BUILDER
 
 FROM unibeautify/clang-format as clang-format-build
 
-FROM golang:alpine
+FROM golang:1.16-alpine
 
 ENV GOLANG_PROTOBUF_VERSION=1.3.5 \
   GOGO_PROTOBUF_VERSION=1.3.2 \

--- a/x/gov/types/content.go
+++ b/x/gov/types/content.go
@@ -28,6 +28,13 @@ type Content interface {
 	String() string
 }
 
+// ContentWithProposer embeds Content interface and adds the GetProposer method used to validate
+// that proposer in the content is equal to proposer in the MsgSubmitProposal.
+type ContentWithProposer interface {
+	Content
+	GetProposer() string
+}
+
 // Handler defines a function that handles a proposal after it has passed the
 // governance process.
 type Handler func(ctx sdk.Context, content Content) error

--- a/x/gov/types/msgs.go
+++ b/x/gov/types/msgs.go
@@ -103,6 +103,10 @@ func (m MsgSubmitProposal) ValidateBasic() error {
 	if err := content.ValidateBasic(); err != nil {
 		return err
 	}
+	contentWithProposer, ok := content.(ContentWithProposer)
+	if ok && contentWithProposer.GetProposer() != m.Proposer {
+		return sdkerrors.Wrap(ErrInvalidProposalContent, "proposer in content is different from the message")
+	}
 
 	return nil
 }


### PR DESCRIPTION
There was no way to add the proposer tho the content of the proposal, becease it woud haven't be validated. 
The current implementation contains the "ContentWithProposer" interface wich embeds the standard "Content" interface and includes the "GetProposer" method. So now if a prioposal content additionaly implements "GetProposer"  method, it will be metached with the proposer in "MsgSubmitProposal" during it's "ValidateBasic" execution.