### PR TITLE
feat: Module delegator slashing protection.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,16 +12,20 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2.1.4
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.16
-      - uses: technote-space/get-diff-action@v5
+      - uses: technote-space/get-diff-action@v6.0.1
         id: git_diff
         with:
           PATTERNS: |
             **/**.go
             go.mod
             go.sum
-      - name: run go linters
-        run: make lint-go
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --out-format=tab
+          skip-go-installation: true
         if: env.GIT_DIFF

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -127,6 +127,11 @@ var (
 		stakingtypes.NotBondedPoolName: {authtypes.Burner, authtypes.Staking},
 		govtypes.ModuleName:            {authtypes.Burner},
 	}
+
+	// module accounts that are allowed to receive tokens
+	allowedReceivingModAcc = map[string]bool{
+		distrtypes.ModuleName: true,
+	}
 )
 
 var (
@@ -239,10 +244,10 @@ func NewSimApp(
 		appCodec, keys[authtypes.StoreKey], app.GetSubspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, maccPerms,
 	)
 	app.BankKeeper = bankkeeper.NewBaseKeeper(
-		appCodec, keys[banktypes.StoreKey], app.AccountKeeper, app.GetSubspace(banktypes.ModuleName), app.ModuleAccountAddrs(),
+		appCodec, keys[banktypes.StoreKey], app.AccountKeeper, app.GetSubspace(banktypes.ModuleName), app.BlockedAddrs(),
 	)
 	stakingKeeper := stakingkeeper.NewKeeper(
-		appCodec, keys[stakingtypes.StoreKey], app.AccountKeeper, app.BankKeeper, app.GetSubspace(stakingtypes.ModuleName),
+		appCodec, keys[stakingtypes.StoreKey], app.AccountKeeper, app.BankKeeper, app.DistrKeeper, app.GetSubspace(stakingtypes.ModuleName),
 	)
 	app.MintKeeper = mintkeeper.NewKeeper(
 		appCodec, keys[minttypes.StoreKey], app.GetSubspace(minttypes.ModuleName), &stakingKeeper,
@@ -447,6 +452,17 @@ func (app *SimApp) ModuleAccountAddrs() map[string]bool {
 	}
 
 	return modAccAddrs
+}
+
+// BlockedAddrs returns all the app's module account addresses that are not
+// allowed to receive external tokens.
+func (app *SimApp) BlockedAddrs() map[string]bool {
+	blockedAddrs := make(map[string]bool)
+	for acc := range maccPerms {
+		blockedAddrs[authtypes.NewModuleAddress(acc).String()] = !allowedReceivingModAcc[acc]
+	}
+
+	return blockedAddrs
 }
 
 // LegacyAmino returns SimApp's amino codec.

--- a/simapp/app_test.go
+++ b/simapp/app_test.go
@@ -41,6 +41,9 @@ func TestSimAppExportAndBlockedAddrs(t *testing.T) {
 	app := NewSimApp(log.NewTMLogger(log.NewSyncWriter(os.Stdout)), db, nil, true, map[int64]bool{}, DefaultNodeHome, 0, encCfg, EmptyAppOptions{})
 
 	for acc := range maccPerms {
+		if allowedReceivingModAcc[acc] == true {
+			continue
+		}
 		require.True(
 			t,
 			app.BankKeeper.BlockedAddr(app.AccountKeeper.GetModuleAddress(acc)),

--- a/x/auth/legacy/v043/store_test.go
+++ b/x/auth/legacy/v043/store_test.go
@@ -668,6 +668,7 @@ func createValidator(t *testing.T, ctx sdk.Context, app *simapp.SimApp, powers i
 		app.GetKey(stakingtypes.StoreKey),
 		app.AccountKeeper,
 		app.BankKeeper,
+		app.DistrKeeper,
 		app.GetSubspace(stakingtypes.ModuleName),
 	)
 

--- a/x/bank/simulation/operations.go
+++ b/x/bank/simulation/operations.go
@@ -12,7 +12,7 @@ import (
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	"github.com/cosmos/cosmos-sdk/x/bank/types"
-	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 )
 
@@ -416,7 +416,7 @@ func getModuleAccounts(ak types.AccountKeeper, ctx sdk.Context, moduleAccCount i
 	moduleAccounts := make([]simtypes.Account, moduleAccCount)
 
 	for i := 0; i < moduleAccCount; i++ {
-		addr := ak.GetModuleAddress(distributiontypes.ModuleName)
+		addr := ak.GetModuleAddress(govtypes.ModuleName)
 		acc := ak.GetAccount(ctx, addr)
 		mAcc := simtypes.Account{
 			Address: acc.GetAddress(),

--- a/x/gov/keeper/common_test.go
+++ b/x/gov/keeper/common_test.go
@@ -28,6 +28,7 @@ func createValidators(t *testing.T, ctx sdk.Context, app *simapp.SimApp, powers 
 		app.GetKey(stakingtypes.StoreKey),
 		app.AccountKeeper,
 		app.BankKeeper,
+		app.DistrKeeper,
 		app.GetSubspace(stakingtypes.ModuleName),
 	)
 

--- a/x/staking/common_test.go
+++ b/x/staking/common_test.go
@@ -46,6 +46,7 @@ func getBaseSimappWithCustomKeeper() (*codec.LegacyAmino, *simapp.SimApp, sdk.Co
 		app.GetKey(types.StoreKey),
 		app.AccountKeeper,
 		app.BankKeeper,
+		app.DistrKeeper,
 		app.GetSubspace(types.ModuleName),
 	)
 	app.StakingKeeper.SetParams(ctx, types.DefaultParams())

--- a/x/staking/keeper/common_test.go
+++ b/x/staking/keeper/common_test.go
@@ -32,6 +32,7 @@ func createTestInput() (*codec.LegacyAmino, *simapp.SimApp, sdk.Context) {
 		app.GetKey(types.StoreKey),
 		app.AccountKeeper,
 		app.BankKeeper,
+		app.DistrKeeper,
 		app.GetSubspace(types.ModuleName),
 	)
 	return app.LegacyAmino(), app, ctx

--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -689,6 +689,29 @@ func (k Keeper) Unbond(
 	return amount, nil
 }
 
+// UnbondAndUndelegateCoins unbonds the tokens from the validator and undelegates them from the not bonded pool to the delegator.
+func (k Keeper) UnbondAndUndelegateCoins(
+	ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, shares sdk.Dec,
+) (amount sdk.Int, err error) {
+	amount, err = k.Unbond(ctx, delAddr, valAddr, shares)
+	if err != nil {
+		return amount, err
+	}
+
+	val, _ := k.GetValidator(ctx, valAddr)
+	if val.IsBonded() {
+		k.bondedTokensToNotBonded(ctx, amount)
+	}
+
+	if err = k.bankKeeper.UndelegateCoinsFromModuleToAccount(
+		ctx, types.NotBondedPoolName, delAddr, sdk.Coins{sdk.NewCoin(k.BondDenom(ctx), amount)},
+	); err != nil {
+		return amount, err
+	}
+
+	return amount, err
+}
+
 // getBeginInfo returns the completion time and height of a redelegation, along
 // with a boolean signaling if the redelegation is complete based on the source
 // validator.

--- a/x/staking/keeper/grpc_query_test.go
+++ b/x/staking/keeper/grpc_query_test.go
@@ -779,6 +779,7 @@ func createValidators(t *testing.T, ctx sdk.Context, app *simapp.SimApp, powers 
 		app.GetKey(types.StoreKey),
 		app.AccountKeeper,
 		app.BankKeeper,
+		app.DistrKeeper,
 		app.GetSubspace(types.ModuleName),
 	)
 

--- a/x/staking/keeper/keeper.go
+++ b/x/staking/keeper/keeper.go
@@ -19,18 +19,20 @@ var _ types.DelegationSet = Keeper{}
 
 // keeper of the staking store
 type Keeper struct {
-	storeKey   sdk.StoreKey
-	cdc        codec.BinaryCodec
-	authKeeper types.AccountKeeper
-	bankKeeper types.BankKeeper
-	hooks      types.StakingHooks
-	paramstore paramtypes.Subspace
+	storeKey    sdk.StoreKey
+	cdc         codec.BinaryCodec
+	authKeeper  types.AccountKeeper
+	bankKeeper  types.BankKeeper
+	distrKeeper types.DistributionKeeper
+	hooks       types.StakingHooks
+	spm         types.SlashingProtestedModules
+	paramstore  paramtypes.Subspace
 }
 
 // NewKeeper creates a new staking Keeper instance
 func NewKeeper(
 	cdc codec.BinaryCodec, key sdk.StoreKey, ak types.AccountKeeper, bk types.BankKeeper,
-	ps paramtypes.Subspace,
+	distrKeeper types.DistributionKeeper, ps paramtypes.Subspace,
 ) Keeper {
 	// set KeyTable if it has not already been set
 	if !ps.HasKeyTable() {
@@ -47,12 +49,13 @@ func NewKeeper(
 	}
 
 	return Keeper{
-		storeKey:   key,
-		cdc:        cdc,
-		authKeeper: ak,
-		bankKeeper: bk,
-		paramstore: ps,
-		hooks:      nil,
+		storeKey:    key,
+		cdc:         cdc,
+		authKeeper:  ak,
+		bankKeeper:  bk,
+		paramstore:  ps,
+		distrKeeper: distrKeeper,
+		hooks:       nil,
 	}
 }
 
@@ -68,6 +71,18 @@ func (k *Keeper) SetHooks(sh types.StakingHooks) *Keeper {
 	}
 
 	k.hooks = sh
+
+	return k
+}
+
+// SetSlashingProtestedModules sets the set of the modules which are protected from the slashing and will be automatically
+// unbonded before the slashing.
+func (k *Keeper) SetSlashingProtestedModules(spm types.SlashingProtestedModules) *Keeper {
+	if k.spm != nil {
+		panic("cannot set slashing protested modules twice")
+	}
+
+	k.spm = spm
 
 	return k
 }

--- a/x/staking/keeper/slash.go
+++ b/x/staking/keeper/slash.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	types "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 // Slash a validator for an infraction committed at a known height
@@ -28,11 +28,6 @@ func (k Keeper) Slash(ctx sdk.Context, consAddr sdk.ConsAddress, infractionHeigh
 		panic(fmt.Errorf("attempted to slash with a negative slash factor: %v", slashFactor))
 	}
 
-	// Amount of slashing = slash slashFactor * power at time of infraction
-	amount := k.TokensFromConsensusPower(ctx, power)
-	slashAmountDec := amount.ToDec().Mul(slashFactor)
-	slashAmount := slashAmountDec.TruncateInt()
-
 	// ref https://github.com/cosmos/cosmos-sdk/issues/1348
 
 	validator, found := k.GetValidatorByConsAddr(ctx, consAddr)
@@ -54,6 +49,21 @@ func (k Keeper) Slash(ctx sdk.Context, consAddr sdk.ConsAddress, infractionHeigh
 	}
 
 	operatorAddress := validator.GetOperator()
+	unbondedAmount, err := k.UnbondSlashingProtectedModules(ctx, operatorAddress)
+	if err != nil {
+		panic(fmt.Errorf("attempted to unbond slashing protected modules: %v: %w ", k.spm(), err))
+	}
+	// reload the validator since it's stake might have been changed
+	validator, _ = k.GetValidatorByConsAddr(ctx, consAddr)
+
+	// amount of slashing = slash slashFactor * power at time of infraction
+	amount := k.TokensFromConsensusPower(ctx, power)
+	// since the unbond is performed just before the slashing we should decrease the total slash amount by the unbond amount.
+	amount = amount.Sub(unbondedAmount)
+	amount = sdk.MaxInt(amount, sdk.ZeroInt()) // defensive.
+
+	slashAmountDec := amount.ToDec().Mul(slashFactor)
+	slashAmount := slashAmountDec.TruncateInt()
 
 	// call the before-modification hook
 	k.BeforeValidatorModified(ctx, operatorAddress)
@@ -296,4 +306,33 @@ func (k Keeper) SlashRedelegation(ctx sdk.Context, srcValidator types.Validator,
 	}
 
 	return totalSlashAmount
+}
+
+// UnbondSlashingProtectedModules - unbonds all slashing protected modules and returns the total unbond amount.
+func (k Keeper) UnbondSlashingProtectedModules(ctx sdk.Context, valAddr sdk.ValAddress) (sdk.Int, error) {
+	unbondedAmount := sdk.ZeroInt()
+	if k.spm == nil {
+		return unbondedAmount, nil
+	}
+	for module := range k.spm() {
+		moduleAddress := k.authKeeper.GetModuleAddress(module)
+		delegation, found := k.GetDelegation(ctx, moduleAddress, valAddr)
+		if !found {
+			continue
+		}
+		// we need to withdraw the delegation reward before the unbond to keep the earned reward
+		if k.distrKeeper.HasDelegatorStartingInfo(ctx, valAddr, moduleAddress) {
+			if _, err := k.distrKeeper.WithdrawDelegationRewards(ctx, moduleAddress, valAddr); err != nil {
+				return unbondedAmount, err
+			}
+		}
+		unbondedDelegation, err := k.UnbondAndUndelegateCoins(ctx, moduleAddress, valAddr, delegation.Shares)
+		if err != nil {
+			return unbondedAmount, err
+		}
+		k.Logger(ctx).Info(fmt.Sprintf("module %s delegation protected from slashing", module), "validator", valAddr.String())
+		unbondedAmount = unbondedAmount.Add(unbondedDelegation)
+	}
+
+	return unbondedAmount, nil
 }

--- a/x/staking/keeper/slash_test.go
+++ b/x/staking/keeper/slash_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/simapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	"github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	"github.com/cosmos/cosmos-sdk/x/staking/teststaking"
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -603,4 +605,113 @@ func TestSlashBoth(t *testing.T) {
 	require.True(t, found)
 	// power not decreased, all stake was bonded since
 	require.Equal(t, int64(10), validator.GetConsensusPower(app.StakingKeeper.PowerReduction(ctx)))
+}
+
+// tests Slash at the current height
+func TestSlashValidatorAtCurrentHeightWithSlashingProtection(t *testing.T) {
+	// use disr types module name to withdraw the reward without errors and
+	moduleDelegatorName := distrtypes.ModuleName
+
+	app, ctx, _, _ := bootstrapSlashTest(t, 10)
+	app.StakingKeeper.SetSlashingProtestedModules(func() map[string]struct{} {
+		return map[string]struct{}{
+			moduleDelegatorName: {},
+		}
+	})
+	app.StakingKeeper.SetHooks(types.NewMultiStakingHooks(app.DistrKeeper.Hooks()))
+
+	valBondTokens := app.StakingKeeper.TokensFromConsensusPower(ctx, 10)
+	valReward := app.StakingKeeper.TokensFromConsensusPower(ctx, 1).ToDec()
+	delBondTokens := app.StakingKeeper.TokensFromConsensusPower(ctx, 2)
+	delProtectedBondTokens := app.StakingKeeper.TokensFromConsensusPower(ctx, 4)
+	delProtectedExpectedReward := app.StakingKeeper.TokensFromConsensusPower(ctx, 875).QuoRaw(1000) // 0.875
+	totalDelegation := valBondTokens.Add(delBondTokens).Add(delProtectedBondTokens)
+
+	fraction := sdk.NewDecWithPrec(5, 1)
+
+	// generate delegator account
+	delAddr := simapp.AddTestAddrs(app, ctx, 1, delBondTokens)[0]
+	// generate protected delegator account
+	err := app.BankKeeper.SendCoinsFromAccountToModule(ctx, simapp.AddTestAddrs(app, ctx, 1, delProtectedBondTokens)[0],
+		moduleDelegatorName, sdk.NewCoins(sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), delProtectedBondTokens)))
+	require.NoError(t, err)
+	delProtectedAddr := app.AccountKeeper.GetModuleAddress(moduleDelegatorName)
+
+	// get already created validator
+	vaConsAddr := sdk.ConsAddress(PKs[0].Address())
+	// delegate from normal account
+	val, found := app.StakingKeeper.GetValidatorByConsAddr(ctx, vaConsAddr)
+	require.True(t, found)
+	// call this function here to init the validator in the distribution module
+	app.StakingKeeper.AfterValidatorCreated(ctx, val.GetOperator())
+
+	// delegate from normal account
+	delShares := delegate(t, app, ctx, vaConsAddr, delAddr, delBondTokens)
+	// delegate from protected account
+	delegate(t, app, ctx, vaConsAddr, delProtectedAddr, delProtectedBondTokens)
+
+	// capture the current bond state
+	bondedPool := app.StakingKeeper.GetBondedPool(ctx)
+	oldBondedPoolBalances := app.BankKeeper.GetAllBalances(ctx, bondedPool.GetAddress())
+	// end block
+	applyValidatorSetUpdates(t, ctx, app.StakingKeeper, 1)
+
+	// mint coins for the distr module
+	require.NoError(t, app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, sdk.NewCoins(sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), valReward.TruncateInt()))))
+	require.NoError(t, app.BankKeeper.SendCoinsFromModuleToModule(ctx, minttypes.ModuleName, distrtypes.ModuleName, sdk.NewCoins(sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), valReward.TruncateInt()))))
+	// add reward to the validator to withdraw by the protected module
+	app.DistrKeeper.AllocateTokensToValidator(ctx, val, sdk.NewDecCoins(sdk.NewDecCoinFromDec(app.StakingKeeper.BondDenom(ctx), valReward)))
+
+	// get current power
+	power := app.StakingKeeper.GetLastValidatorPower(ctx, val.GetOperator())
+	require.Equal(t, app.StakingKeeper.TokensToConsensusPower(ctx, totalDelegation), power)
+
+	// increase the block number to be able to get the reward
+	ctx = app.BaseApp.NewContext(false, tmproto.Header{Height: app.LastBlockHeight() + 1})
+	// now slash based on the current power
+	app.StakingKeeper.Slash(ctx, vaConsAddr, ctx.BlockHeight(), power, fraction)
+	// end block
+	applyValidatorSetUpdates(t, ctx, app.StakingKeeper, 1)
+
+	// read updated test
+	val, found = app.StakingKeeper.GetValidator(ctx, val.GetOperator())
+	assert.True(t, found)
+	// power decreased, the protected delegation was remove from the calculation
+	// since the module is protected from the slashing
+	expectedPower := app.StakingKeeper.TokensToConsensusPower(ctx,
+		totalDelegation.Sub(delProtectedBondTokens).
+			ToDec().Mul(fraction).TruncateInt())
+	power = val.GetConsensusPower(app.StakingKeeper.PowerReduction(ctx))
+	require.Equal(t, expectedPower, power)
+
+	// pool bonded shares decreased
+	newBondedPoolBalances := app.BankKeeper.GetAllBalances(ctx, bondedPool.GetAddress())
+	diffTokens := oldBondedPoolBalances.Sub(newBondedPoolBalances).AmountOf(app.StakingKeeper.BondDenom(ctx))
+	require.Equal(t, totalDelegation.Sub(delProtectedBondTokens).ToDec().Mul(fraction).TruncateInt().
+		// add undelegated tokens
+		Add(delProtectedBondTokens).String(), diffTokens.String())
+
+	// check the delegation slashing
+	unbondDelegationAmount, err := app.StakingKeeper.Unbond(ctx, delAddr, val.GetOperator(), delShares)
+	assert.NoError(t, err)
+	// the amount 50% less because of the slashing
+	assert.Equal(t, delBondTokens.ToDec().Mul(fraction).TruncateInt(), unbondDelegationAmount)
+
+	// check that protected module has no delegation now
+	_, found = app.StakingKeeper.GetDelegation(ctx, delProtectedAddr, val.GetOperator())
+	assert.False(t, found)
+
+	delProtectedBalance := app.BankKeeper.GetAllBalances(ctx, delProtectedAddr)
+	assert.Equal(t, sdk.NewCoins(sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), delProtectedBondTokens.Add(delProtectedExpectedReward))), delProtectedBalance)
+}
+
+func delegate(t *testing.T, app *simapp.SimApp, ctx sdk.Context, vaConsAddr sdk.ConsAddress, delAddr sdk.AccAddress, delTokens sdk.Int) sdk.Dec {
+	t.Helper()
+
+	val, found := app.StakingKeeper.GetValidatorByConsAddr(ctx, vaConsAddr)
+	require.True(t, found)
+	delShares, err := app.StakingKeeper.Delegate(ctx, delAddr, delTokens, types.Unbonded, val, true)
+	require.NoError(t, err)
+	require.Equal(t, delTokens.String(), delShares.TruncateInt().String())
+	return delShares
 }

--- a/x/staking/types/expected_keepers.go
+++ b/x/staking/types/expected_keepers.go
@@ -7,8 +7,8 @@ import (
 
 // DistributionKeeper expected distribution keeper (noalias)
 type DistributionKeeper interface {
-	GetFeePoolCommunityCoins(ctx sdk.Context) sdk.DecCoins
-	GetValidatorOutstandingRewardsCoins(ctx sdk.Context, val sdk.ValAddress) sdk.DecCoins
+	HasDelegatorStartingInfo(ctx sdk.Context, val sdk.ValAddress, del sdk.AccAddress) bool
+	WithdrawDelegationRewards(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) (sdk.Coins, error)
 }
 
 // AccountKeeper defines the expected account keeper (noalias)
@@ -102,3 +102,6 @@ type StakingHooks interface {
 	AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress)
 	BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, fraction sdk.Dec)
 }
+
+// The SlashingProtestedModules is a type used for the slashing protected modules names.
+type SlashingProtestedModules func() map[string]struct{}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

In some cases, we need to delegate using the module and need a feature to protect such delegation from the validator slashing.
The implementation contains the automatic withdrawal reward and undelegation just before the validator slashing. The slashing amount is computed based on the updated power after the undelegation.

Closes: #15

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---