### PR TITLE
feat: Vesting account withdrawal reward limitation.

### DIFF
--- a/x/auth/vesting/exported/exported.go
+++ b/x/auth/vesting/exported/exported.go
@@ -12,6 +12,10 @@ import (
 type VestingAccount interface {
 	types.AccountI
 
+	// AddOriginalVesting increases the original vesting spreading the amount according to the
+	// vesting account strategy.
+	AddOriginalVesting(amount sdk.Coins)
+
 	// LockedCoins returns the set of coins that are not spendable (i.e. locked),
 	// defined as the vesting coins that are not delegated.
 	//

--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -261,6 +261,12 @@ func (cva ContinuousVestingAccount) GetVestingCoins(blockTime time.Time) sdk.Coi
 	return cva.OriginalVesting.Sub(cva.GetVestedCoins(blockTime))
 }
 
+// AddOriginalVesting increases the original vesting spreading the amount according to the
+// vesting account strategy.
+func (cva *ContinuousVestingAccount) AddOriginalVesting(amount sdk.Coins) {
+	cva.OriginalVesting = cva.OriginalVesting.Add(amount...)
+}
+
 // LockedCoins returns the set of coins that are not spendable (i.e. locked),
 // defined as the vesting coins that are not delegated.
 func (cva ContinuousVestingAccount) LockedCoins(blockTime time.Time) sdk.Coins {
@@ -387,6 +393,39 @@ func (pva PeriodicVestingAccount) GetVestingCoins(blockTime time.Time) sdk.Coins
 	return pva.OriginalVesting.Sub(pva.GetVestedCoins(blockTime))
 }
 
+// AddOriginalVesting increases the original vesting spreading the amount according to the
+// vesting account strategy. For the periodic vesting it also equally increases the periods amount based on
+// the period amount and total vesting amount.
+func (pva *PeriodicVestingAccount) AddOriginalVesting(amount sdk.Coins) {
+	amount = amount.Sort()
+	incSum := sdk.NewCoins()
+	for i, period := range pva.VestingPeriods {
+		for _, incCoin := range amount {
+			incDenom := incCoin.Denom
+			prevOriginalAmt := pva.OriginalVesting.AmountOf(incDenom)
+			periodAmt := period.Amount.AmountOf(incDenom)
+			if periodAmt.IsZero() {
+				continue
+			}
+			incPeriodAmt := incCoin.Amount.ToDec().Mul(periodAmt.ToDec()).Quo(prevOriginalAmt.ToDec()).TruncateInt()
+			incPeriodCoin := sdk.NewCoin(incDenom, incPeriodAmt)
+			period.Amount = period.Amount.Add(incPeriodCoin)
+			incSum = incSum.Add(incPeriodCoin)
+			pva.VestingPeriods[i] = period
+		}
+	}
+
+	// new denoms and truncation remainder will be added to the last period
+	remainder := amount.Sub(incSum)
+	if !remainder.IsZero() && len(pva.VestingPeriods) != 0 {
+		lastPeriod := pva.VestingPeriods[len(pva.VestingPeriods)-1]
+		lastPeriod.Amount = lastPeriod.Amount.Add(remainder...)
+		pva.VestingPeriods[len(pva.VestingPeriods)-1] = lastPeriod
+	}
+
+	pva.OriginalVesting = pva.OriginalVesting.Add(amount...)
+}
+
 // LockedCoins returns the set of coins that are not spendable (i.e. locked),
 // defined as the vesting coins that are not delegated.
 func (pva PeriodicVestingAccount) LockedCoins(blockTime time.Time) sdk.Coins {
@@ -498,6 +537,12 @@ func (dva DelayedVestingAccount) GetVestingCoins(blockTime time.Time) sdk.Coins 
 	return dva.OriginalVesting.Sub(dva.GetVestedCoins(blockTime))
 }
 
+// AddOriginalVesting increases the original vesting spreading the amount according to the
+// vesting account strategy.
+func (dva *DelayedVestingAccount) AddOriginalVesting(amount sdk.Coins) {
+	dva.OriginalVesting = dva.OriginalVesting.Add(amount...)
+}
+
 // LockedCoins returns the set of coins that are not spendable (i.e. locked),
 // defined as the vesting coins that are not delegated.
 func (dva DelayedVestingAccount) LockedCoins(blockTime time.Time) sdk.Coins {
@@ -553,6 +598,12 @@ func (plva PermanentLockedAccount) GetVestedCoins(_ time.Time) sdk.Coins {
 // vesting account.
 func (plva PermanentLockedAccount) GetVestingCoins(_ time.Time) sdk.Coins {
 	return plva.OriginalVesting
+}
+
+// AddOriginalVesting increases the original vesting spreading the amount according to the
+// vesting account strategy.
+func (plva *PermanentLockedAccount) AddOriginalVesting(amount sdk.Coins) {
+	plva.OriginalVesting = plva.OriginalVesting.Add(amount...)
 }
 
 // LockedCoins returns the set of coins that are not spendable (i.e. locked),

--- a/x/distribution/keeper/delegation.go
+++ b/x/distribution/keeper/delegation.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	vestexported "github.com/cosmos/cosmos-sdk/x/auth/vesting/exported"
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
@@ -171,8 +172,8 @@ func (k Keeper) withdrawDelegationRewards(ctx sdk.Context, val stakingtypes.Vali
 		if err != nil {
 			return nil, err
 		}
+		k.addVestingRewards(ctx, del.GetDelegatorAddr(), coins)
 	}
-
 	// update the outstanding rewards and the community pool only if the
 	// transaction was successful
 	k.SetValidatorOutstandingRewards(ctx, del.GetValidatorAddr(), types.ValidatorOutstandingRewards{Rewards: outstanding.Sub(rewards)})
@@ -189,4 +190,13 @@ func (k Keeper) withdrawDelegationRewards(ctx sdk.Context, val stakingtypes.Vali
 	k.DeleteDelegatorStartingInfo(ctx, del.GetValidatorAddr(), del.GetDelegatorAddr())
 
 	return coins, nil
+}
+
+func (k Keeper) addVestingRewards(ctx sdk.Context, delAddr sdk.AccAddress, amt sdk.Coins) {
+	vacc, ok := k.authKeeper.GetAccount(ctx, delAddr).(vestexported.VestingAccount)
+	if !ok || vacc.GetVestingCoins(ctx.BlockTime()).IsZero(){
+		return
+	}
+	vacc.AddOriginalVesting(amt)
+	k.authKeeper.SetAccount(ctx, vacc)
 }

--- a/x/distribution/keeper/delegation_test.go
+++ b/x/distribution/keeper/delegation_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -337,6 +338,161 @@ func TestWithdrawDelegationRewardsBasic(t *testing.T) {
 		sdk.Coins{sdk.NewCoin(sdk.DefaultBondDenom, exp)},
 		app.BankKeeper.GetAllBalances(ctx, sdk.AccAddress(valAddrs[0])),
 	)
+}
+
+func TestWithdrawDelegationRewardsVesting(t *testing.T) {
+	app := simapp.Setup(false)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+
+	val1BalAmt := app.StakingKeeper.TokensFromConsensusPower(ctx, 1000)
+	val1VestingAmt := val1BalAmt.QuoRaw(4)
+	val1VestingRatio := val1VestingAmt.ToDec().Quo(val1BalAmt.ToDec()) // 25% locked in vesting
+	val1DelAmt := app.StakingKeeper.TokensFromConsensusPower(ctx, 100)
+	val1Commission := sdk.NewDecWithPrec(5, 1) // 50%
+
+	del1BalAmt := app.StakingKeeper.TokensFromConsensusPower(ctx, 1000)
+	del1VestingAmt := del1BalAmt // all coins vested
+	del1DelAmt := del1BalAmt     // full delegation
+
+	del2BalAmt := app.StakingKeeper.TokensFromConsensusPower(ctx, 1000)
+	del2VestingAmt := sdk.ZeroInt() // zero in vesting
+	del2DelAmt := del2BalAmt        // full delegation
+
+	allocatedReward := app.StakingKeeper.TokensFromConsensusPower(ctx, 200)
+	allocatedRewardWithoutCommission := allocatedReward.ToDec().Mul(val1Commission)
+
+	delTotalAmt := val1DelAmt.Add(del1DelAmt).Add(del2DelAmt)
+
+	val1FullReward := val1DelAmt.ToDec().Quo(delTotalAmt.ToDec()).Mul(allocatedRewardWithoutCommission)
+	del1FullReward := del1DelAmt.ToDec().Quo(delTotalAmt.ToDec()).Mul(allocatedRewardWithoutCommission)
+	del2FullReward := del2DelAmt.ToDec().Quo(delTotalAmt.ToDec()).Mul(allocatedRewardWithoutCommission)
+
+	val1Addr := simapp.ConvertAddrsToValAddrs(simapp.AddTestVestingAddrs(app, ctx, 1, val1BalAmt, val1VestingAmt))[0]
+	val2Addr := simapp.ConvertAddrsToValAddrs(simapp.AddTestAddrs(app, ctx, 1, val1BalAmt))[0] // just have more than one validator
+	del1Addr := simapp.AddTestVestingAddrs(app, ctx, 1, del1BalAmt, del1VestingAmt)[0]
+	del2Addr := simapp.AddTestVestingAddrs(app, ctx, 1, del2BalAmt, del2VestingAmt)[0]
+
+	tstaking := teststaking.NewHelper(t, ctx, app.StakingKeeper)
+
+	// set module account coins
+	distrAcc := app.DistrKeeper.GetDistributionAccount(ctx)
+	require.NoError(t, simapp.FundModuleAccount(app.BankKeeper, ctx, distrAcc.GetName(), sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, allocatedReward))))
+	app.AccountKeeper.SetModuleAccount(ctx, distrAcc)
+
+	// create validator with 50% commission
+	tstaking.Commission = stakingtypes.NewCommissionRates(val1Commission, val1Commission, sdk.NewDec(0))
+	tstaking.CreateValidator(val1Addr, valConsPk1, val1DelAmt, true)
+	tstaking.CreateValidator(val2Addr, valConsPk2, val1DelAmt, true)
+
+	tstaking.Delegate(del1Addr, val1Addr, del1DelAmt)
+	tstaking.Delegate(del2Addr, val1Addr, del2DelAmt)
+
+	// assert correct initial balance
+	expTokens := val1BalAmt.Sub(val1DelAmt)
+	require.Equal(t,
+		sdk.Coins{sdk.NewCoin(sdk.DefaultBondDenom, expTokens)},
+		app.BankKeeper.GetAllBalances(ctx, sdk.AccAddress(val1Addr)),
+	)
+
+	// end block to bond validator
+	staking.EndBlocker(ctx, app.StakingKeeper)
+
+	// next block
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
+
+	// fetch validator and delegation
+	val1 := app.StakingKeeper.Validator(ctx, val1Addr)
+
+	// allocate some rewards
+	app.DistrKeeper.AllocateTokensToValidator(ctx, val1, sdk.DecCoins{sdk.NewDecCoin(sdk.DefaultBondDenom, allocatedReward)})
+
+	require.Equal(t, uint64(6), app.DistrKeeper.GetValidatorHistoricalReferenceCount(ctx))
+
+	// withdraw rewards
+
+	// val1
+	val1Reward, err := app.DistrKeeper.WithdrawDelegationRewards(ctx, sdk.AccAddress(val1Addr), val1Addr)
+	require.NoError(t, err)
+	require.Equal(t, val1FullReward.TruncateInt(), val1Reward.AmountOf(sdk.DefaultBondDenom))
+	// locked based on ratio
+	require.Equal(t, val1VestingAmt.Sub(val1DelAmt).Add(val1FullReward.Mul(val1VestingRatio).TruncateInt()),
+		app.BankKeeper.LockedCoins(ctx, sdk.AccAddress(val1Addr)).AmountOf(sdk.DefaultBondDenom))
+	// full on balance
+	val1ExpBalance := val1BalAmt.Sub(val1DelAmt).Add(val1FullReward.TruncateInt())
+	require.Equal(t,
+		sdk.Coins{sdk.NewCoin(sdk.DefaultBondDenom, val1ExpBalance)},
+		app.BankKeeper.GetAllBalances(ctx, sdk.AccAddress(val1Addr)),
+	)
+
+	// del1
+	del1Reward, err := app.DistrKeeper.WithdrawDelegationRewards(ctx, del1Addr, val1Addr)
+	require.NoError(t, err)
+	require.Equal(t, del1FullReward.TruncateInt(), del1Reward.AmountOf(sdk.DefaultBondDenom))
+	// full reward locked
+	require.Equal(t, del1FullReward.TruncateInt(), app.BankKeeper.LockedCoins(ctx, del1Addr).AmountOf(sdk.DefaultBondDenom))
+	// only reward on balance
+	require.Equal(t, del1FullReward.TruncateInt(), app.BankKeeper.GetAllBalances(ctx, del1Addr).AmountOf(sdk.DefaultBondDenom))
+
+	// del2
+	del2Reward, err := app.DistrKeeper.WithdrawDelegationRewards(ctx, del2Addr, val1Addr)
+	require.NoError(t, err)
+	require.Equal(t, del2FullReward.TruncateInt(), del2Reward.AmountOf(sdk.DefaultBondDenom))
+	// nothing locked
+	require.Equal(t, sdk.ZeroInt(), app.BankKeeper.LockedCoins(ctx, del2Addr).AmountOf(sdk.DefaultBondDenom))
+	// only reward on balance
+	require.Equal(t, del2Reward, app.BankKeeper.GetAllBalances(ctx, del2Addr))
+
+	// validator commission
+
+	valCommissionReward, err := app.DistrKeeper.WithdrawValidatorCommission(ctx, val1Addr)
+	require.Equal(t, allocatedReward.ToDec().Mul(val1Commission).TruncateInt(), valCommissionReward.AmountOf(sdk.DefaultBondDenom))
+	require.NoError(t, err)
+
+	// assert correct validator balance + commission
+	valExpFinalBalance := val1BalAmt.Sub(val1DelAmt).
+		Add(val1FullReward.TruncateInt()).                             // reward
+		Add(allocatedReward.ToDec().Mul(val1Commission).TruncateInt()) // commission
+
+	require.Equal(t,
+		sdk.Coins{sdk.NewCoin(sdk.DefaultBondDenom, valExpFinalBalance)},
+		app.BankKeeper.GetAllBalances(ctx, sdk.AccAddress(val1Addr)),
+	)
+
+	// ----- check when all vested
+
+	// next block
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
+	ctx = ctx.WithBlockTime(ctx.BlockTime().Add(time.Minute)) // increase time to pass the vesting periods
+
+	// val1
+	val1Reward, err = app.DistrKeeper.WithdrawDelegationRewards(ctx, sdk.AccAddress(val1Addr), val1Addr)
+	require.NoError(t, err)
+	require.Equal(t, sdk.ZeroInt(), val1Reward.AmountOf(sdk.DefaultBondDenom))
+	// locked based on ratio
+	require.Equal(t, sdk.ZeroInt(), app.BankKeeper.LockedCoins(ctx, sdk.AccAddress(val1Addr)).AmountOf(sdk.DefaultBondDenom))
+	// full on balance
+	require.Equal(t,
+		sdk.Coins{sdk.NewCoin(sdk.DefaultBondDenom, valExpFinalBalance)},
+		app.BankKeeper.GetAllBalances(ctx, sdk.AccAddress(val1Addr)),
+	)
+
+	// del1
+	del1Reward, err = app.DistrKeeper.WithdrawDelegationRewards(ctx, del1Addr, val1Addr)
+	require.NoError(t, err)
+	require.Equal(t, sdk.ZeroInt(), del1Reward.AmountOf(sdk.DefaultBondDenom))
+	// nothing locked
+	require.Equal(t, sdk.ZeroInt(), app.BankKeeper.LockedCoins(ctx, del1Addr).AmountOf(sdk.DefaultBondDenom))
+	// only reward on balance
+	require.Equal(t, del1FullReward.TruncateInt(), app.BankKeeper.GetAllBalances(ctx, del1Addr).AmountOf(sdk.DefaultBondDenom))
+
+	// del2
+	del2Reward, err = app.DistrKeeper.WithdrawDelegationRewards(ctx, del2Addr, val1Addr)
+	require.NoError(t, err)
+	require.Equal(t, sdk.ZeroInt(), del2Reward.AmountOf(sdk.DefaultBondDenom))
+	// nothing locked
+	require.Equal(t, sdk.ZeroInt(), app.BankKeeper.LockedCoins(ctx, del2Addr).AmountOf(sdk.DefaultBondDenom))
+	// only reward on balance
+	require.Equal(t, del2FullReward.TruncateInt(), app.BankKeeper.GetAllBalances(ctx, del2Addr).AmountOf(sdk.DefaultBondDenom))
 }
 
 func TestCalculateRewardsAfterManySlashesInSameBlock(t *testing.T) {

--- a/x/distribution/spec/04_messages.md
+++ b/x/distribution/spec/04_messages.md
@@ -61,6 +61,10 @@ rewards = rewards + (R(B) - R(PN)) * stake
 The historical rewards are calculated retroactively by playing back all the slashes and then attenuating the delegator's stake at each step.
 The final calculated stake is equivalent to the actual staked coins in the delegation with a margin of error due to rounding errors.
 
+For the vesting account, with the coins still locked in vesting, the reward amount will be equally spread in the vesting
+based on the vesting account type strategy: for all types, the OriginalVesting amount will be increased by the reward amount. For the PeriodicVestingAccount
+the amount will be additionally spread among the periods based on the amount in each period.
+
 Response:
 
 +++ https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50

--- a/x/distribution/types/expected_keepers.go
+++ b/x/distribution/types/expected_keepers.go
@@ -15,6 +15,8 @@ type AccountKeeper interface {
 
 	// TODO remove with genesis 2-phases refactor https://github.com/cosmos/cosmos-sdk/issues/2862
 	SetModuleAccount(sdk.Context, types.ModuleAccountI)
+
+	SetAccount(ctx sdk.Context, acc types.AccountI)
 }
 
 // BankKeeper defines the expected interface needed to retrieve account balances.


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

For the vesting account, with the coins still locked in vesting, the reward amount will be equally spread in the vesting
based on the vesting account type strategy: for all types, the OriginalVesting amount will be increased by the reward amount. For the PeriodicVestingAccount
the amount will be additionally spread among the periods based on the amount in each period.

---