### PR TITLE
refactor: Remove DistributionKeeper dependency from the staking keeper.

### DIFF
--- a/simapp/app.go
+++ b/simapp/app.go
@@ -247,7 +247,7 @@ func NewSimApp(
 		appCodec, keys[banktypes.StoreKey], app.AccountKeeper, app.GetSubspace(banktypes.ModuleName), app.BlockedAddrs(),
 	)
 	stakingKeeper := stakingkeeper.NewKeeper(
-		appCodec, keys[stakingtypes.StoreKey], app.AccountKeeper, app.BankKeeper, app.DistrKeeper, app.GetSubspace(stakingtypes.ModuleName),
+		appCodec, keys[stakingtypes.StoreKey], app.AccountKeeper, app.BankKeeper, app.GetSubspace(stakingtypes.ModuleName),
 	)
 	app.MintKeeper = mintkeeper.NewKeeper(
 		appCodec, keys[minttypes.StoreKey], app.GetSubspace(minttypes.ModuleName), &stakingKeeper,

--- a/x/auth/legacy/v043/store_test.go
+++ b/x/auth/legacy/v043/store_test.go
@@ -668,7 +668,6 @@ func createValidator(t *testing.T, ctx sdk.Context, app *simapp.SimApp, powers i
 		app.GetKey(stakingtypes.StoreKey),
 		app.AccountKeeper,
 		app.BankKeeper,
-		app.DistrKeeper,
 		app.GetSubspace(stakingtypes.ModuleName),
 	)
 

--- a/x/gov/keeper/common_test.go
+++ b/x/gov/keeper/common_test.go
@@ -28,7 +28,6 @@ func createValidators(t *testing.T, ctx sdk.Context, app *simapp.SimApp, powers 
 		app.GetKey(stakingtypes.StoreKey),
 		app.AccountKeeper,
 		app.BankKeeper,
-		app.DistrKeeper,
 		app.GetSubspace(stakingtypes.ModuleName),
 	)
 

--- a/x/staking/common_test.go
+++ b/x/staking/common_test.go
@@ -46,7 +46,6 @@ func getBaseSimappWithCustomKeeper() (*codec.LegacyAmino, *simapp.SimApp, sdk.Co
 		app.GetKey(types.StoreKey),
 		app.AccountKeeper,
 		app.BankKeeper,
-		app.DistrKeeper,
 		app.GetSubspace(types.ModuleName),
 	)
 	app.StakingKeeper.SetParams(ctx, types.DefaultParams())

--- a/x/staking/keeper/common_test.go
+++ b/x/staking/keeper/common_test.go
@@ -32,7 +32,6 @@ func createTestInput() (*codec.LegacyAmino, *simapp.SimApp, sdk.Context) {
 		app.GetKey(types.StoreKey),
 		app.AccountKeeper,
 		app.BankKeeper,
-		app.DistrKeeper,
 		app.GetSubspace(types.ModuleName),
 	)
 	return app.LegacyAmino(), app, ctx

--- a/x/staking/keeper/grpc_query_test.go
+++ b/x/staking/keeper/grpc_query_test.go
@@ -779,7 +779,6 @@ func createValidators(t *testing.T, ctx sdk.Context, app *simapp.SimApp, powers 
 		app.GetKey(types.StoreKey),
 		app.AccountKeeper,
 		app.BankKeeper,
-		app.DistrKeeper,
 		app.GetSubspace(types.ModuleName),
 	)
 

--- a/x/staking/keeper/keeper.go
+++ b/x/staking/keeper/keeper.go
@@ -19,20 +19,18 @@ var _ types.DelegationSet = Keeper{}
 
 // keeper of the staking store
 type Keeper struct {
-	storeKey    sdk.StoreKey
-	cdc         codec.BinaryCodec
-	authKeeper  types.AccountKeeper
-	bankKeeper  types.BankKeeper
-	distrKeeper types.DistributionKeeper
-	hooks       types.StakingHooks
-	spm         types.SlashingProtestedModules
-	paramstore  paramtypes.Subspace
+	storeKey   sdk.StoreKey
+	cdc        codec.BinaryCodec
+	authKeeper types.AccountKeeper
+	bankKeeper types.BankKeeper
+	hooks      types.StakingHooks
+	spm        types.SlashingProtestedModules
+	paramstore paramtypes.Subspace
 }
 
 // NewKeeper creates a new staking Keeper instance
 func NewKeeper(
-	cdc codec.BinaryCodec, key sdk.StoreKey, ak types.AccountKeeper, bk types.BankKeeper,
-	distrKeeper types.DistributionKeeper, ps paramtypes.Subspace,
+	cdc codec.BinaryCodec, key sdk.StoreKey, ak types.AccountKeeper, bk types.BankKeeper, ps paramtypes.Subspace,
 ) Keeper {
 	// set KeyTable if it has not already been set
 	if !ps.HasKeyTable() {
@@ -49,13 +47,12 @@ func NewKeeper(
 	}
 
 	return Keeper{
-		storeKey:    key,
-		cdc:         cdc,
-		authKeeper:  ak,
-		bankKeeper:  bk,
-		paramstore:  ps,
-		distrKeeper: distrKeeper,
-		hooks:       nil,
+		storeKey:   key,
+		cdc:        cdc,
+		authKeeper: ak,
+		bankKeeper: bk,
+		paramstore: ps,
+		hooks:      nil,
 	}
 }
 

--- a/x/staking/keeper/slash.go
+++ b/x/staking/keeper/slash.go
@@ -320,12 +320,6 @@ func (k Keeper) UnbondSlashingProtectedModules(ctx sdk.Context, valAddr sdk.ValA
 		if !found {
 			continue
 		}
-		// we need to withdraw the delegation reward before the unbond to keep the earned reward
-		if k.distrKeeper.HasDelegatorStartingInfo(ctx, valAddr, moduleAddress) {
-			if _, err := k.distrKeeper.WithdrawDelegationRewards(ctx, moduleAddress, valAddr); err != nil {
-				return unbondedAmount, err
-			}
-		}
 		unbondedDelegation, err := k.UnbondAndUndelegateCoins(ctx, moduleAddress, valAddr, delegation.Shares)
 		if err != nil {
 			return unbondedAmount, err

--- a/x/staking/types/expected_keepers.go
+++ b/x/staking/types/expected_keepers.go
@@ -5,12 +5,6 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
-// DistributionKeeper expected distribution keeper (noalias)
-type DistributionKeeper interface {
-	HasDelegatorStartingInfo(ctx sdk.Context, val sdk.ValAddress, del sdk.AccAddress) bool
-	WithdrawDelegationRewards(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) (sdk.Coins, error)
-}
-
 // AccountKeeper defines the expected account keeper (noalias)
 type AccountKeeper interface {
 	IterateAccounts(ctx sdk.Context, process func(authtypes.AccountI) (stop bool))


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

The DistributionKeeper was used to withdraw the reward before the unbound, but the unbond has an integrated distribution hook that already withdraws the reward, so we don't need to do it twice.
