### PR TITLE
Add mistakenly omitted commit

### DIFF
--- a/x/staking/keeper/pool.go
+++ b/x/staking/keeper/pool.go
@@ -64,7 +64,14 @@ func (k Keeper) TotalBondedTokens(ctx sdk.Context) sdk.Int {
 
 // StakingTokenSupply staking tokens from the total supply
 func (k Keeper) StakingTokenSupply(ctx sdk.Context) sdk.Int {
-	return k.bankKeeper.GetSupply(ctx, k.BondDenom(ctx)).Amount
+	stakeSupply := k.bankKeeper.GetSupply(ctx, k.BondDenom(ctx)).Amount
+	daoAddr := k.authKeeper.GetModuleAddress("dao")
+	if daoAddr != nil {
+		daoSupply := k.bankKeeper.GetBalance(ctx, daoAddr, k.BondDenom(ctx))
+		stakeSupply = stakeSupply.Sub(daoSupply.Amount)
+	}
+
+	return stakeSupply
 }
 
 // BondedRatio the fraction of the staking tokens which are currently bonded


### PR DESCRIPTION
This got through because of mixups, and my APR tests didn't check what would happen if the chain started at a very high APR. I new something was anomalous when the APR would be slightly rising up from where it started, now it will immediately cap at ~20% on chain startup or upgrade and go downwards to where it should be.